### PR TITLE
Skip Overpass filtering for some formats

### DIFF
--- a/utils/manager.py
+++ b/utils/manager.py
@@ -119,11 +119,20 @@ class RunManager(object):
         if prereq and prereq not in self.results:
             self.run_format(prereq)
 
+        osm_feature_selection = self.feature_selection
+        if (OSM_PBF in self.formats
+                or GarminIMG in self.formats
+                or OsmAndOBF in self.formats
+                or MWM in self.formats):
+            # skip Overpass predicate push-down so intermediate formats can
+            # contain all data
+            osm_feature_selection = None
+
         if formatcls == OSM_XML:
             task = OSM_XML(
                 self.aoi_geom,
-                self.feature_selection,
                 os.path.join(self.dir, 'export.osm'),
+                osm_feature_selection,
                 url=self.overpass_api_url)
 
         if formatcls == OSM_PBF:

--- a/utils/osm_xml.py
+++ b/utils/osm_xml.py
@@ -27,7 +27,8 @@ class OSM_XML(object):
 
     name = "osm_xml"
     description = 'OSM XML'
-    default_template = Template("""[maxsize:$maxsize][timeout:$timeout];(
+    basic_template = Template('[maxsize:$maxsize][timeout:$timeout];(node($geom);<;>>;>;);out meta;')
+    filter_template = Template("""[maxsize:$maxsize][timeout:$timeout];(
             (
                 $nodes
             );
@@ -39,7 +40,7 @@ class OSM_XML(object):
             );>>;>;
             );out meta;""")
 
-    def __init__(self, aoi_geom,feature_selection, output_xml, 
+    def __init__(self, aoi_geom, output_xml, feature_selection=None,
                 url='http://overpass-api.de/api/',
                 overpass_max_size=4294967296,
                 timeout=3200):
@@ -94,13 +95,20 @@ class OSM_XML(object):
             [coords.extend((y, x)) for x, y in self.aoi_geom.coords[0]]
             geom = 'poly:"{}"'.format(' '.join(map(str, coords)))
 
-        nodes,ways,relations = self.feature_selection.overpass_filter()
-        args.update({
-            'nodes':"\n".join(['node(' + geom + ')' + f + ';' for f in nodes]),
-            'ways':"\n".join(['way(' + geom + ')' + f + ';'  for f in ways]),
-            'relations':"\n".join(['relation(' + geom + ')' + f + ';' for f in relations]),
-        })
-        query = OSM_XML.default_template.safe_substitute(args)
+        if self.feature_selection:
+            nodes,ways,relations = self.feature_selection.overpass_filter()
+            args.update({
+                'nodes':"\n".join(['node(' + geom + ')' + f + ';' for f in nodes]),
+                'ways':"\n".join(['way(' + geom + ')' + f + ';'  for f in ways]),
+                'relations':"\n".join(['relation(' + geom + ')' + f + ';' for f in relations]),
+            })
+
+            query = OSM_XML.filter_template.safe_substitute(args)
+        else:
+            args.update({
+                'geom': geom,
+            })
+            query = OSM_XML.basic_template.safe_substitute(args)
 
         # set up required paths
         LOG.debug("Query started at: %s" % datetime.now())


### PR DESCRIPTION
Previously (before the optimization that pushed tag filtering to Overpass), when users selected PBF, Garmin, OsmAnd, or Maps.me output they would get unfiltered versions of those files (because filtering occurred when creating other target formats).

The UI currently matches this, as it disables feature selection when only these formats are selected.

After adding Overpass-level filtering, these formats inherited filters applied to the "filterable" formats.

I could make a case for both behaviors (though in the case of the latter, we'd want to enable the feature selection UI).

This PR shifts behavior back to the former in preparation for adding POSM bundle support (where the requirement is that the PBF contain *all* data available in the AOI).

An alternate implementation (once POSM bundle support is added) could skip Overpass filtering when "POSM bundle" is checked, but that introduces confusion where PBF means something different under varying conditions.

Thoughts?