### PR TITLE
POSM bundle

### DIFF
--- a/ui/app/components/utils.js
+++ b/ui/app/components/utils.js
@@ -63,6 +63,16 @@ export const AVAILABLE_EXPORT_FORMATS = {
     <span key="osmand_obf">
       MBTiles <code>.mbtiles</code>
     </span>
+  ),
+  full_pbf: (
+    <span key="full_pbf">
+      Unfiltered OSM <code>.pbf</code>
+    </span>
+  ),
+  bundle: (
+    <span key="bundle">
+      <a href="http://posm.io/">POSM</a> bundle
+    </span>
   )
 };
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,8 @@ from .garmin_img import GarminIMG
 from .osmand_obf import OsmAndOBF
 from .mbtiles import MBTiles
 from .mwm import MWM
+from .posm_bundle import POSMBundle
+from .unfiltered_pbf import UnfilteredPBF
 
 
 class ThematicShp(object):
@@ -22,7 +24,7 @@ class ThematicGpkg(object):
 FORMAT_NAMES = {}
 for cls in [
         OSM_XML, OSM_PBF, Geopackage, Shapefile, KML, GarminIMG, OsmAndOBF,
-        MBTiles, MWM
+        MBTiles, MWM, POSMBundle, UnfilteredPBF
 ]:
     FORMAT_NAMES[cls.name] = cls
 

--- a/utils/manager.py
+++ b/utils/manager.py
@@ -119,11 +119,20 @@ class RunManager(object):
         if prereq and prereq not in self.results:
             self.run_format(prereq)
 
+        osm_feature_selection = self.feature_selection
+        if (OSM_PBF in self.formats
+                or GarminIMG in self.formats
+                or OsmAndOBF in self.formats
+                or MWM in self.formats):
+            # skip Overpass predicate push-down so intermediate formats can
+            # contain all data
+            osm_feature_selection = None
+
         if formatcls == OSM_XML:
             task = OSM_XML(
                 self.aoi_geom,
-                self.feature_selection,
                 os.path.join(self.dir, 'export.osm'),
+                osm_feature_selection,
                 url=self.overpass_api_url)
 
         if formatcls == OSM_PBF:

--- a/utils/osm_xml.py
+++ b/utils/osm_xml.py
@@ -128,4 +128,3 @@ class OSM_XML(object):
     @property
     def is_complete(self):
         return os.path.isfile(self.output_xml)
-

--- a/utils/osm_xml.py
+++ b/utils/osm_xml.py
@@ -27,7 +27,8 @@ class OSM_XML(object):
 
     name = "osm_xml"
     description = 'OSM XML'
-    default_template = Template("""[maxsize:$maxsize][timeout:$timeout];(
+    basic_template = Template('[maxsize:$maxsize][timeout:$timeout];(node($geom);<;>>;>;);out meta;')
+    filter_template = Template("""[maxsize:$maxsize][timeout:$timeout];(
             (
                 $nodes
             );
@@ -39,7 +40,7 @@ class OSM_XML(object):
             );>>;>;
             );out meta;""")
 
-    def __init__(self, aoi_geom,feature_selection, output_xml, 
+    def __init__(self, aoi_geom, output_xml, feature_selection=None,
                 url='http://overpass-api.de/api/',
                 overpass_max_size=4294967296,
                 timeout=3200):
@@ -94,13 +95,20 @@ class OSM_XML(object):
             [coords.extend((y, x)) for x, y in self.aoi_geom.coords[0]]
             geom = 'poly:"{}"'.format(' '.join(map(str, coords)))
 
-        nodes,ways,relations = self.feature_selection.overpass_filter()
-        args.update({
-            'nodes':"\n".join(['node(' + geom + ')' + f + ';' for f in nodes]),
-            'ways':"\n".join(['way(' + geom + ')' + f + ';'  for f in ways]),
-            'relations':"\n".join(['relation(' + geom + ')' + f + ';' for f in relations]),
-        })
-        query = OSM_XML.default_template.safe_substitute(args)
+        if self.feature_selection:
+            nodes,ways,relations = self.feature_selection.overpass_filter()
+            args.update({
+                'nodes':"\n".join(['node(' + geom + ')' + f + ';' for f in nodes]),
+                'ways':"\n".join(['way(' + geom + ')' + f + ';'  for f in ways]),
+                'relations':"\n".join(['relation(' + geom + ')' + f + ';' for f in relations]),
+            })
+
+            query = OSM_XML.filter_template.safe_substitute(args)
+        else:
+            args.update({
+                'geom': geom,
+            })
+            query = OSM_XML.basic_template.safe_substitute(args)
 
         # set up required paths
         LOG.debug("Query started at: %s" % datetime.now())

--- a/utils/posm_bundle.py
+++ b/utils/posm_bundle.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+import tarfile
+
+from django.utils.text import slugify
+
+from .artifact import Artifact
+
+LOG = logging.getLogger(__name__)
+
+
+class POSMBundle(object):
+    name = 'bundle'
+    description = 'POSM Bundle'
+
+    def __init__(self,
+                 name,
+                 description,
+                 input_dir,
+                 extent,
+                 mbtiles_source=None,
+                 mbtiles_minzoom=None,
+                 mbtiles_maxzoom=None):
+        self.name = name
+        self.description = description
+        self.input_dir = input_dir
+        self.extent = extent
+        self.mbtiles_source = mbtiles_source
+        self.mbtiles_minzoom = mbtiles_minzoom
+        self.mbtiles_maxzoom = mbtiles_maxzoom
+        self.output = os.path.join(input_dir, "bundle.tar.gz")
+
+    def run(self):
+        if self.is_complete:
+            LOG.debug("Skipping POSM bundle, file exists")
+            return
+
+        # assemble contents
+        contents = {}
+        prefix = slugify(self.name, allow_unicode=True)
+
+        with tarfile.open(self.output, "w|gz") as bundle:
+            for filename in os.listdir(self.input_dir):
+                _, ext = os.path.splitext(filename)
+                path = os.path.join(self.input_dir, filename)
+
+                if ext == ".mbtiles":
+                    target_filename = "tiles/{}.mbtiles".format(prefix)
+                    contents[target_filename] = {
+                        "type": "MBTiles",
+                        "minzoom": self.mbtiles_minzoom,
+                        "maxzoom": self.mbtiles_maxzoom,
+                        "source": self.mbtiles_source,
+                        "name": self.name,
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if ext == ".obf":
+                    target_filename = "navigation/{}.obf".format(prefix)
+                    contents[target_filename] = {
+                        "type": "OsmAnd",
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if ext == ".mwm":
+                    target_filename = "navigation/{}.mwm".format(prefix)
+                    contents[target_filename] = {
+                        "type": "Maps.me",
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if filename == "gmapsupp.img":
+                    target_filename = "navigation/{}.img".format(prefix)
+                    contents[target_filename] = {
+                        "type": "Garmin IMG",
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if ext == ".gpkg":
+                    target_filename = "data/{}.gpkg".format(prefix)
+                    contents[target_filename] = {
+                        "type": "Geopackage",
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if ext == ".kml":
+                    target_filename = "data/{}.kml".format(prefix)
+                    contents[target_filename] = {
+                        "type": "KML",
+                    }
+
+                    bundle.add(path, target_filename)
+
+                if filename == "unfiltered.pbf":
+                    target_filename = "osm/{}.pbf".format(prefix)
+                    contents[target_filename] = {
+                        "type": "OSM/PBF",
+                    }
+
+                    bundle.add(path, target_filename)
+
+            manifest = os.path.join(self.input_dir, "manifest.json")
+            with open(manifest, "w") as m:
+                json.dump({
+                    "title": self.name,
+                    "name": prefix,
+                    "description": self.description,
+                    "bbox": self.extent,
+                    "content": contents,
+                }, m)
+
+            bundle.add(manifest, "manifest.json")
+
+    @property
+    def results(self):
+        return [Artifact([self.output], self.name)]
+
+    @property
+    def is_complete(self):
+        return os.path.isfile(self.output)

--- a/utils/tests/test_integration.py
+++ b/utils/tests/test_integration.py
@@ -68,6 +68,8 @@ class TestIntegration(unittest.TestCase):
         aoi_geom = Polygon.from_bbox((-17.417,14.754,-17.395,14.772))
         fmts = [Geopackage,Shapefile,KML]
         r = RunManager(
+            'shp_per_theme',
+            'Shapefiles per theme',
             fmts,
             aoi_geom,
             TEST_FEATURE_SELECTION,
@@ -99,6 +101,8 @@ class TestIntegration(unittest.TestCase):
         aoi_geom = Polygon.from_bbox((-17.417,14.754,-17.395,14.772))
         fmts = [Geopackage,Shapefile,KML]
         r = RunManager(
+            'shp',
+            'Shapefiles',
             fmts,
             aoi_geom,
             TEST_FEATURE_SELECTION,
@@ -127,6 +131,8 @@ class TestIntegration(unittest.TestCase):
         self.setup_stage_dir()
         aoi_geom = Polygon.from_bbox((-17.417,14.754,-17.395,14.772))
         r = RunManager(
+            'Garmin IMG',
+            'Garmin maps!',
             [GarminIMG],
             aoi_geom,
             TEST_FEATURE_SELECTION,
@@ -141,4 +147,3 @@ class TestIntegration(unittest.TestCase):
         zipper.run(r.results[GarminIMG].results)
         z = zipper.zipped_resources
         self.assertEqual(len(z),1) # one themeless img
-

--- a/utils/unfiltered_pbf.py
+++ b/utils/unfiltered_pbf.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+from string import Template
+from subprocess import PIPE, Popen
+
+from .artifact import Artifact
+from .osm_xml import OSM_XML
+
+LOG = logging.getLogger(__name__)
+
+
+class InvalidOsmXmlException(Exception):
+    pass
+
+
+class UnfilteredPBF(object):
+    name = 'full_pbf'
+    description = 'Unfiltered OSM PBF'
+    cmd = Template('osmconvert $osm --out-pbf >$pbf')
+
+    def __init__(self, aoi_geom, output_pbf, url):
+        self.aoi_geom = aoi_geom
+        self.output_pbf = output_pbf
+        self.url = url
+
+    def run(self):
+        if self.is_complete:
+            LOG.debug("Skipping UnfilteredPBF, file exists")
+            return
+
+        osm_xml = "{}.xml".format(self.output_pbf)
+
+        osm_xml_task = OSM_XML(self.aoi_geom, osm_xml, url=self.url)
+        osm_xml_task.run()
+
+        convert_cmd = self.cmd.safe_substitute({
+            'osm': osm_xml,
+            'pbf': self.output_pbf
+        })
+
+        LOG.debug('Running: %s' % convert_cmd)
+
+        p = Popen(convert_cmd, shell=True, stdout=PIPE, stderr=PIPE)
+        stdout, stderr = p.communicate()
+
+        if stderr:
+            with open(self.input_xml, 'rb') as fd:
+                sample = fd.readlines(8)
+                raise InvalidOsmXmlException(sample)
+
+        LOG.debug('Osmconvert complete')
+
+    @property
+    def results(self):
+        return [Artifact([self.output_pbf], UnfilteredPBF.name)]
+
+    @property
+    def is_complete(self):
+        return os.path.isfile(self.output_pbf)


### PR DESCRIPTION
This introduces an "unfiltered PBF" output format (and exposes it in the UI) which is a prerequisite for POSM bundles.

This also implements support for creating POSM bundles, including bundling of other (optional) requested resources (not including shapefiles due to the variance in filenames). It also bypasses zipping (since POSM bundles need to be tarballs), something that we should consider for compressed formats / ones where unzipping is inconvenient (e.g. PBF, MWM, OBF).