### PR TITLE
Pin doc publish workflow @main --> @1.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/docs.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   publish_docs:
-    uses: hotosm/gh-workflows/.github/workflows/mkdocs_build.yml@main
+    uses: hotosm/gh-workflows/.github/workflows/mkdocs_build.yml@1.0.1


### PR DESCRIPTION
We have started using version control for gh-workflows.

v1.0.1 released, with a working docs publish, so pin to that.