### PR TITLE
Handle null e.g. in the case of manual bbox

### DIFF
--- a/ui/app/components/aoi/ExportAOI.js
+++ b/ui/app/components/aoi/ExportAOI.js
@@ -137,7 +137,7 @@ export class ExportAOI extends Component {
 
   handleSearch = result => {
     var geojson;
-    if (result.adminName2.startsWith('ISO3')){
+    if (result.adminName2?.startsWith('ISO3')){
       try {
         geojson = JSON.parse(JSON.stringify(result.bbox));
       } catch (e) {


### PR DESCRIPTION
The interface used to support entering your own bounding box as a comma-separated list of 4 numbers. This is now broken because adminName2 will be null.
```
Uncaught TypeError: Cannot read properties of undefined (reading 'startsWith')
    at A.handleSearch (ExportAOI.js:140:27)
    at A.handleChange (SearchAOIToolbar.js:53:18)
    at Object.<anonymous> (SearchAOIToolbar.js:29:12)
```
This fix uses optional chaining to avoid this error.